### PR TITLE
Fixes BIND_ADRESS typo in mysql start script

### DIFF
--- a/mysql/mysql-type.yml
+++ b/mysql/mysql-type.yml
@@ -59,7 +59,7 @@ node_types:
             DB_NAME: { get_property: [SELF, db_name] }
             DB_USER: { get_property: [SELF, db_user] }
             DB_PASSWORD: { get_property: [SELF, db_password] }
-            BIND_ADRESS: { get_property: [SELF, bind_address] }
+            BIND_ADDRESS: { get_property: [SELF, bind_address] }
           implementation: scripts/start_mysql.sh
     artifacts:
       - configs: configs

--- a/mysql/scripts/start_mysql.sh
+++ b/mysql/scripts/start_mysql.sh
@@ -65,7 +65,7 @@ function UpdateMySQLConf {
     sudo cp $configs/mysqld_charset.cnf /etc/mysql/conf.d/mysqld_charset.cnf
   fi
 
-  if [ "$BIND_ADRESS" == "true" ]; then
+  if [ "$BIND_ADDRESS" == "true" ]; then
     sudo sed -i "s/bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/my.cnf
   fi
 }


### PR DESCRIPTION
Typo was preventing remote access to mysql as it was previously binding to 127.0.0.1
